### PR TITLE
Add cache mapping for Nintendo 3DS debugger RAM

### DIFF
--- a/AsmExtra.h
+++ b/AsmExtra.h
@@ -80,7 +80,7 @@ void enableSlot2Cache(void);
 void disableSlot2Cache(void);
 
 /**
- * Reassigns the DSi MPU regions so that main RAM and the New 3DS debugger RAM
+ * Reassigns the DSi MPU regions so that main RAM and the Nintendo 3DS debugger RAM
  * mirror at 0x0C000000-0x0DFFFFFF are data-cacheable.
  */
 void enableN3dsExtraCache(void);

--- a/AsmExtra.h
+++ b/AsmExtra.h
@@ -79,6 +79,15 @@ void enableSlot2Cache(void);
  */
 void disableSlot2Cache(void);
 
+/**
+ * Reassigns the DSi MPU regions so that main RAM and the New 3DS debugger RAM
+ * mirror at 0x0C000000-0x0DFFFFFF are data-cacheable.
+ */
+void enableN3dsExtraCache(void);
+
+/** Restores the BlocksDS DSi MPU region layout. */
+void disableN3dsExtraCache(void);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/AsmExtra.s
+++ b/AsmExtra.s
@@ -19,6 +19,8 @@
 	.global debugOutput_asm
 	.global enableSlot2Cache
 	.global disableSlot2Cache
+	.global enableN3dsExtraCache
+	.global disableN3dsExtraCache
 	.global bytecopy_
 	.global memmem_
 	.global memclr_
@@ -313,6 +315,74 @@ disableSlot2Cache:
 	mrc	p15,0,r0,c2,c0,0
 	bic r0,r0,#(1 << 3)
 	mcr	p15,0,r0,c2,c0,0
+	bx lr
+;@----------------------------------------------------------------------------
+enableN3dsExtraCache:
+	.type enableN3dsExtraCache STT_FUNC
+;@----------------------------------------------------------------------------
+	// BlocksDS maps region 5 (0x0C000000, 32MB) uncached and region 6
+	// (0x02000000, 16MB) cached in DSi mode. Move cached main RAM to region
+	// 3 first, then use the higher-priority region 6 for the complete debugger
+	// RAM mirror. This makes 0x0D000000 cacheable without ever unmapping the
+	// code that is currently executing from main RAM.
+	mrs r12,cpsr
+	orr r1,r12,#0x80
+	msr cpsr_c,r1
+
+	mov r0,#0
+	mcr p15,0,r0,c7,c14,0		;@ Clean and invalidate data cache.
+	mcr p15,0,r0,c7,c10,4		;@ Drain write buffer.
+
+	ldr r0,=0x0200002F			;@ Region 3: main RAM, 16MB.
+	mcr p15,0,r0,c6,c3,0
+	mrc p15,0,r0,c2,c0,0
+	orr r0,r0,#(1 << 3)
+	mcr p15,0,r0,c2,c0,0
+	mrc p15,0,r0,c2,c0,1
+	orr r0,r0,#(1 << 3)
+	mcr p15,0,r0,c2,c0,1
+	mrc p15,0,r0,c3,c0,0
+	orr r0,r0,#(1 << 3)
+	mcr p15,0,r0,c3,c0,0
+
+	ldr r0,=0x0C000031			;@ Region 6: DSi debugger RAM, 32MB.
+	mcr p15,0,r0,c6,c6,0
+	mov r0,#0
+	mcr p15,0,r0,c7,c5,0		;@ Invalidate instruction cache.
+	mcr p15,0,r0,c7,c10,4
+	msr cpsr_c,r12
+	bx lr
+;@----------------------------------------------------------------------------
+disableN3dsExtraCache:
+	.type disableN3dsExtraCache STT_FUNC
+;@----------------------------------------------------------------------------
+	// Restore region 6 before region 3 so execution from main RAM remains
+	// mapped throughout the transition.
+	mrs r12,cpsr
+	orr r1,r12,#0x80
+	msr cpsr_c,r1
+
+	mov r0,#0
+	mcr p15,0,r0,c7,c14,0
+	mcr p15,0,r0,c7,c10,4
+
+	ldr r0,=0x0200002F			;@ Region 6: cached main RAM, 16MB.
+	mcr p15,0,r0,c6,c6,0
+	ldr r0,=0x0300002D			;@ Region 3: DSi switchable IWRAM, 8MB.
+	mcr p15,0,r0,c6,c3,0
+	mrc p15,0,r0,c2,c0,0
+	bic r0,r0,#(1 << 3)
+	mcr p15,0,r0,c2,c0,0
+	mrc p15,0,r0,c2,c0,1
+	bic r0,r0,#(1 << 3)
+	mcr p15,0,r0,c2,c0,1
+	mrc p15,0,r0,c3,c0,0
+	bic r0,r0,#(1 << 3)
+	mcr p15,0,r0,c3,c0,0
+	mov r0,#0
+	mcr p15,0,r0,c7,c5,0
+	mcr p15,0,r0,c7,c10,4
+	msr cpsr_c,r12
 	bx lr
 ;@----------------------------------------------------------------------------
 bytecopy_:					;@ void bytecopy_(u8 *dst, const u8 *src, int count)

--- a/CartridgeRAM.c
+++ b/CartridgeRAM.c
@@ -371,7 +371,12 @@ u32 cartRamSize() {
 vu16 *cartRamUnlock() {
 	if (unlockFunc) {
 		sysSetCartOwner(BUS_OWNER_ARM9);
-		disableSlot2Cache();
+		if (rType == N3DS_RAM) {
+			disableN3dsExtraCache();
+		}
+		else {
+			disableSlot2Cache();
+		}
 		return unlockFunc();
 	}
 	return NULL;
@@ -380,7 +385,21 @@ vu16 *cartRamUnlock() {
 void cartRamLock() {
 	if (lockFunc) {
 		sysSetCartOwner(BUS_OWNER_ARM9);
-		disableSlot2Cache();
+		if (rType == N3DS_RAM) {
+			disableN3dsExtraCache();
+		}
+		else {
+			disableSlot2Cache();
+		}
 		lockFunc();
+	}
+}
+
+void cartRamEnableCache() {
+	if (rType == N3DS_RAM) {
+		enableN3dsExtraCache();
+	}
+	else if (rType != DETECT_RAM) {
+		enableSlot2Cache();
 	}
 }

--- a/CartridgeRAM.h
+++ b/CartridgeRAM.h
@@ -71,6 +71,9 @@ vu16 *cartRamUnlock(void);
 /** Tries to lock the RAM, this may not work on all kinds of carts. */
 void cartRamLock(void);
 
+/** Enable the appropriate cache mapping after a ROM has been loaded. */
+void cartRamEnableCache(void);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif


### PR DESCRIPTION
## What changed
- add MPU helpers for the Nintendo 3DS debugger RAM mirror at `0x0C000000-0x0DFFFFFF`
- keep main RAM cacheable while switching MPU regions
- select the matching cache routine from `CartridgeRAM`

## Scope
The new MPU path is selected only when `CartridgeRAM` detects the existing `N3DS_RAM` type. All DS/DS Lite cartridge RAM types continue to use the existing SLOT-2 cache path. Despite the historical enum/helper name, this is not limited to New 3DS hardware; the path was also validated on an Old 2DS with DSpico.

## Why
DSpico exposes extra RAM through the Nintendo 3DS debugger-memory mirror. The existing SLOT-2 cache routine does not cover this mapping, which leaves ROM access uncached.

## Validation
- built in both DS and DSi configurations through NitroSwan
- regression tests cover enable/disable MPU layout and cartridge-RAM dispatch
- validated on an Old 2DS using DSpico without frame drops